### PR TITLE
support snippet format is json

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -4,7 +4,7 @@ const jsontoxml = require('jsontoxml')
 const add = require('./add')
 const { atomMatcher, vscodeMatcher, sublimeMatcher } = require('../utils/matchers')
 const { atomComment, vscodeComment, sublimeComment } = require('../utils/comments')
-const { files, home, exists, write, read, log } = require('../utils/general')
+const { files, home, exists, write, read, readRaw, log } = require('../utils/general')
 const { SNIPSTER_CONFIG, ATOM_PATH, VSCODE_PATH, SUBLIME_PATH, STYLE_FILE_PATH, ALL_FILE_PATH } = require('../utils/constants')
 
 const addSnippetsToEditor = async (snippets, editor) => {
@@ -69,7 +69,7 @@ const publish = async () => {
       .toLowerCase().replace('style', STYLE_FILE_PATH)
       .replace('all', ALL_FILE_PATH).split('+')
     const prefix = path.substring(path.lastIndexOf('/') + 1, path.lastIndexOf('.'))
-    const body = await read(path)
+    const body = await readRaw(path)
 
     // for each language in the extension, add the snippet
     langs.forEach(lang => {

--- a/utils/general.js
+++ b/utils/general.js
@@ -86,18 +86,19 @@ const write = (path, contents) => {
   }
 }
 
-const read = async (path, options) => {
+const readRaw = async (path, options) => {
   const readFile = promisify(fs.readFile)
   try {
     const res = await readFile(path, options || 'utf-8')
-    try {
-      const json = JSON.parse(stripJsonComments(res))
-      return json
-    } catch (jsonErr) {}
     return res
   } catch (err) {
     fail(err)
   }
+}
+
+const read = async (path, options) => {
+  const res = await readRaw(path, options)
+  return JSON.parse(stripJsonComments(res))
 }
 
 const copy = (pathFrom, pathTo) => {
@@ -109,6 +110,7 @@ const copy = (pathFrom, pathTo) => {
 
 module.exports = {
   read,
+  readRaw,
   write,
   copy,
   success,


### PR DESCRIPTION
Given a snippet like this
```
{
	"a": 1
}
```

It'll try to parse it and return json instead of string, cause app error.